### PR TITLE
fix: correctly handle user config

### DIFF
--- a/lua/java-deps/config.lua
+++ b/lua/java-deps/config.lua
@@ -23,7 +23,10 @@ local M = {
 }
 M.setup = function(config)
   if config then
-    M = vim.tbl_extend("force", M, config)
+    local new_config = vim.tbl_deep_extend("force", M, config)
+    for key, value in pairs(new_config) do
+      M[key] = value
+    end
   end
 end
 


### PR DESCRIPTION
Currently, the `setup()` function in [config.lua](https://github.com/JavaHello/java-deps.nvim/blob/master/lua/java-deps/config.lua#L24-L28) reassigns the entire module table `M` to a new table returned by `vim.tbl_extend`.  As a result, any existing references to the original `M` (such as the one returned when requiring the module) becomes stale. This causes inconsistent behavior where:
- accessing keys from the table returned by `require("java-deps.config")` will result in the old values (ignoring any user  supplied config).
- functions within the module (like `config.get_split_command()` or `config.has_numbers()`) uses the new values (the ones from the user config).

That is because they are operating on different tables.

a minimal example that showcases the issue:
```lua
local function require_config()
    local M = {
        key = "original value"
    }
    M.setup = function (config)
        if config then
            M = vim.tbl_extend("force", M, config)
        end
    end
    M.get_key = function ()
        return M.key
    end
    return M
end

local config = require_config()
config.setup({ key = "new value"})
print(config.key)
print(config.get_key())
```
This will output
```
original value
new value
```


To fix this, I merged the new configuration directly into the existing `M` table. I also changed `vim.tbl_extend` to `vim.tbl_deep_extend` since the config has nested tables. There are other ways to fix this, but I think this approach minimize changes to the current codebase.